### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn watch"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ yarn dev # to launch server on the specified port in the .env file at root
 ```
 yarn test
 ```
+```
+[![Run on Repl.it](https://repl.it/badge/github/JackGaark/node-skeleton-api)](https://repl.it/github/JackGaark/node-skeleton-api)
+```


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JackG2A/node-skeleton-api).